### PR TITLE
이미 퀴즈를 푼 눈사람 예외 처리

### DIFF
--- a/server/src/main/java/com/nuneddine/server/exception/ErrorCode.java
+++ b/server/src/main/java/com/nuneddine/server/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     AWS_S3_NOT_CONNECTED(HttpStatus.SERVICE_UNAVAILABLE, "AWS-002", "AWS S3 연결에 실패했습니다."),
     FAILED_TO_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "AWS-003", "파일 읽기 오류 혹은 잘못된 입력입니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "FILE-001", "업로드하려는 파일의 크기가 너무 큽니다."),
+    ALREADY_SOLVED_QUIZ(HttpStatus.TOO_MANY_REQUESTS, "QUIZ-001", "이미 푼 퀴즈입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/server/src/main/java/com/nuneddine/server/service/SnowmanService.java
+++ b/server/src/main/java/com/nuneddine/server/service/SnowmanService.java
@@ -5,6 +5,8 @@ import com.nuneddine.server.dto.request.KakaoOAuthRequestDto;
 import com.nuneddine.server.dto.request.SnowmanRequestDto;
 import com.nuneddine.server.dto.request.SnowmanUpdateRequestDto;
 import com.nuneddine.server.dto.response.*;
+import com.nuneddine.server.exception.CustomException;
+import com.nuneddine.server.exception.ErrorCode;
 import com.nuneddine.server.repository.*;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -189,7 +191,7 @@ public class SnowmanService {
 
         // 해당 사용자가 이미 푼 퀴즈라면
         if (memberSnowmanRepository.findByMemberAndSnowman(member, snowman).isPresent()) {
-            throw new IllegalStateException("이미 퀴즈를 푼 기록이 있습니다.");
+            throw new CustomException(ErrorCode.ALREADY_SOLVED_QUIZ);
         }
 
         // 새로운 member snowman 추가


### PR DESCRIPTION
## 🦁 기존 예외 처리 수정

## 🎈 카테고리

- [] User 관련
- [] Item 관련
- [x] Snowman 관련

## 🕑 PR 생성 날짜

- 2024/11/15

## 🔍 작업 내용

- 이미 푼 퀴즈를 또 시도하는 경우 기존 예외 처리 결과 반환이 403으로 의미가 잘 드러나지 않았음
- custom exception을 추가하여 어떤 문제인지 알기 쉽도록 개선함

## 📢 Notes

- custom exception을 만들어서 처리해보는 건 어떨까요?

## 🖼 스크린샷

  
![image](https://github.com/user-attachments/assets/5b5a755e-ea55-4457-8bf7-38e1d7286fc3)

