### PR TITLE
눈사람 만들 때 사용자 만들기 횟수 차감

### DIFF
--- a/server/src/main/java/com/nuneddine/server/controller/SnowmanController.java
+++ b/server/src/main/java/com/nuneddine/server/controller/SnowmanController.java
@@ -9,6 +9,8 @@ import com.nuneddine.server.dto.response.SnowmanAllDetailResponseDto;
 import com.nuneddine.server.dto.response.SnowmanDetailResponseDto;
 import com.nuneddine.server.dto.response.SnowmanQuizResponseDto;
 import com.nuneddine.server.dto.response.SnowmanResponseDto;
+import com.nuneddine.server.exception.CustomException;
+import com.nuneddine.server.exception.ErrorCode;
 import com.nuneddine.server.service.JwtService;
 import com.nuneddine.server.service.MemberService;
 import com.nuneddine.server.service.SnowmanService;
@@ -29,6 +31,8 @@ public class SnowmanController {
     @Autowired
     MemberService memberService;
 
+    private static final int MAX_SNOWMAN = 3;
+
     // 맵 눈사람 리스트업
     @GetMapping("/map/{mapNumber}")
     public ResponseEntity<List<SnowmanResponseDto>> getSnowmansByMapNumber(@PathVariable(value = "mapNumber") int mapNumber) {
@@ -47,8 +51,12 @@ public class SnowmanController {
         String token = header.substring(7);
         Long memberId = jwtService.getMemberIdFromToken(token);
         Member member = memberService.getMemberById(memberId);
+        if (member.getBuild() >= MAX_SNOWMAN) {
+            throw new CustomException(ErrorCode.USER_CREATED_ALL_SNOWMAN);
+        }
 
         Long snowmanId = snowmanService.createSnowman(snowmanRequestDto, mapNumber, member);
+        member.updateBuild();
         return new ResponseEntity<>(snowmanId, HttpStatus.CREATED);
     }
 

--- a/server/src/main/java/com/nuneddine/server/domain/Member.java
+++ b/server/src/main/java/com/nuneddine/server/domain/Member.java
@@ -44,4 +44,8 @@ public class Member extends BaseTimeEntity {
     public void updateUsername(String username) {
         this.username = username;
     }
+
+    public void updateBuild() {
+        this.build += 1;
+    }
 }

--- a/server/src/main/java/com/nuneddine/server/exception/ErrorCode.java
+++ b/server/src/main/java/com/nuneddine/server/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-001", "해당 ID를 가진 사용자를 찾을 수 없습니다."),
     USER_NOT_FOUND_GIVEN_KAKAO_ID(HttpStatus.NOT_FOUND, "USER-002", "해당 kakaoID를 가진 사용자를 찾을 수 없습니다."),
+    USER_CREATED_ALL_SNOWMAN(HttpStatus.TOO_MANY_REQUESTS, "USER-003", "이미 눈사람을 3개 만들어서 더 이상 만들 수 없습니다."),
     AWS_S3_ACCESS_DENIED(HttpStatus.FORBIDDEN, "AWS-001", "AWS S3에 접근할 수 있는 권한이 없거나 인증에 실패했습니다."),
     AWS_S3_NOT_CONNECTED(HttpStatus.SERVICE_UNAVAILABLE, "AWS-002", "AWS S3 연결에 실패했습니다."),
     FAILED_TO_UPLOAD_FILE(HttpStatus.BAD_REQUEST, "AWS-003", "파일 읽기 오류 혹은 잘못된 입력입니다."),


### PR DESCRIPTION
## 🦁 이제 눈사람을 만들 때 횟수가 차감되고 3개 이상 눈사람을 가지고 있는 사용자는 눈사람을 만들 수 없습니다

## 🎈 카테고리

- [x] User 관련
- [] Item 관련
- [x] Snowman 관련

## 🕑 PR 생성 날짜

- 2024/11/15

## 🔍 작업 내용

- 눈사람을 만들 때 사용자의 build 필드 1 증가
- build 필드가 3 이상이라면 눈사람을 만들 수 없도록 예외처리

## 📢 Notes

- 눈사람 삭제 기능도 만들어야 되네요...??

## 🖼 스크린샷

  X
