### PR TITLE
FIX: remove imgUrl field for custom Item

### DIFF
--- a/server/src/main/java/com/nuneddine/server/domain/Item.java
+++ b/server/src/main/java/com/nuneddine/server/domain/Item.java
@@ -19,15 +19,13 @@ public class Item {
 
     @Column(unique = true) // 일단 unique로 해둠
     private String itemName;
-    private String imgUrl; // custom item용 imgUrl, default=null
 
     @Enumerated(EnumType.STRING)
     private ItemCategory itemCategory;
 
     @Builder
-    public Item(String itemName, String imgUrl,ItemCategory itemCategory) {
+    public Item(String itemName ,ItemCategory itemCategory) {
         this.itemName = itemName;
-        this.imgUrl = imgUrl;
         this.itemCategory = itemCategory;
     }
 }

--- a/server/src/main/java/com/nuneddine/server/service/ItemService.java
+++ b/server/src/main/java/com/nuneddine/server/service/ItemService.java
@@ -39,7 +39,6 @@ public class ItemService {
     // push 할 때는 이 파일 경로를 주석 처리
 //    @Value("${json.file.path}")
 //    private String filePath;
-    
     // ec2에서 사용할 filePath
     private String filePath = System.getProperty("user.home") + "/Backend/server/src/main/resources/defaultItems.json";
 
@@ -113,7 +112,6 @@ public class ItemService {
         List<MemberItem> memberItems = memberItemRepository.findByMember(member);
         return memberItems.stream()
                 .map(MemberItem::getItem)
-                .filter(item -> item.getImgUrl() == null)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## 🦁 PR Title : 커스텀 아이템용 imgUrl 필드 제거 및 가챠 정상화

## 🎈 카테고리

- [] User 관련
- [x] Item 관련
- [] Snowman 관련

## 🕑 PR 생성 날짜

- 2024/11/15

## 🔍 작업 내용

- 가챠시에 이미 있는 아이템도 뽑히는 문제 발생 -> ImgUrl필드 null 여부로 커스텀 아이템을 판단하고, 가챠에 반영했는데
커스텀 아이템 삭제하면서 해당 로직 제거로 가챠 정상화

## 📢 Notes

- gotcha가 아니라 gacha가 맞습니다......

## 🖼 스크린샷

  X
