### PR TITLE
사용자 눈사람 생성 횟수, 포인트, 퀴즈 기회 증감 기능 구현

### DIFF
--- a/server/src/main/java/com/nuneddine/server/controller/SnowmanController.java
+++ b/server/src/main/java/com/nuneddine/server/controller/SnowmanController.java
@@ -1,7 +1,6 @@
 package com.nuneddine.server.controller;
 
 import com.nuneddine.server.domain.Member;
-import com.nuneddine.server.domain.MemberSnowman;
 import com.nuneddine.server.dto.request.SnowmanUpdateRequestDto;
 import com.nuneddine.server.dto.request.SolveQuizRequestDto;
 import com.nuneddine.server.dto.request.SnowmanRequestDto;
@@ -56,7 +55,7 @@ public class SnowmanController {
         }
 
         Long snowmanId = snowmanService.createSnowman(snowmanRequestDto, mapNumber, member);
-        member.updateBuild();
+        member.increaseBuild();
         return new ResponseEntity<>(snowmanId, HttpStatus.CREATED);
     }
 

--- a/server/src/main/java/com/nuneddine/server/domain/Member.java
+++ b/server/src/main/java/com/nuneddine/server/domain/Member.java
@@ -45,7 +45,27 @@ public class Member extends BaseTimeEntity {
         this.username = username;
     }
 
-    public void updateBuild() {
+    public void increaseBuild() {
         this.build += 1;
+    }
+
+    public void decreaseBuild() {
+        this.build -= 1;
+    }
+
+    public void updateChance() {
+        this.chance = 3;
+    }
+
+    public void decreaseChance() {
+        this.chance -= 1;
+    }
+
+    public void increasePoint() {
+        this.point += 100;
+    }
+
+    public void decreasePoint() {
+        this.point -= 300;
     }
 }


### PR DESCRIPTION
## 🦁 사용자 눈사람 생성 횟수, 포인트, 퀴즈 기회 증감

## 🎈 카테고리

- [x] User 관련
- [] Item 관련
- [] Snowman 관련

## 🕑 PR 생성 날짜

- 2024/11/16

## 🔍 작업 내용

- Member 클래스의 build, chance, point 필드 수정 메서드 추가

## 📢 Notes

- 눈사람 생성, 삭제, 가챠 시도, 퀴즈 시도 서비스 로직에서 member 필드도 수정 관리해주세요

## 🖼 스크린샷

  X
