### PR TITLE
자정에 사용자 퀴즈 도전 기회 초기화

### DIFF
--- a/server/src/main/java/com/nuneddine/server/ServerApplication.java
+++ b/server/src/main/java/com/nuneddine/server/ServerApplication.java
@@ -3,8 +3,10 @@ package com.nuneddine.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class ServerApplication {
 

--- a/server/src/main/java/com/nuneddine/server/repository/MemberRepository.java
+++ b/server/src/main/java/com/nuneddine/server/repository/MemberRepository.java
@@ -2,10 +2,16 @@ package com.nuneddine.server.repository;
 
 import com.nuneddine.server.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     public Optional<Member> findByKakaoId(Long kakaoId);
+
+    @Modifying
+    @Query("UPDATE Member m SET m.chance = :defaultValue")
+    public void resetFieldsToDefault(int defaultValue);
 }

--- a/server/src/main/java/com/nuneddine/server/util/ResetFieldScheduler.java
+++ b/server/src/main/java/com/nuneddine/server/util/ResetFieldScheduler.java
@@ -1,0 +1,21 @@
+package com.nuneddine.server.util;
+
+import com.nuneddine.server.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ResetFieldScheduler {
+
+    private final MemberRepository memberRepository;
+
+    //매일 자정에 실행 (초 분 시 일 월 요일)
+    @Scheduled(cron = "0 3 16 * * ?")
+    @Transactional
+    public void resetFields() {
+        memberRepository.resetFieldsToDefault(3);
+    }
+}

--- a/server/src/main/java/com/nuneddine/server/util/ResetFieldScheduler.java
+++ b/server/src/main/java/com/nuneddine/server/util/ResetFieldScheduler.java
@@ -13,7 +13,7 @@ public class ResetFieldScheduler {
     private final MemberRepository memberRepository;
 
     //매일 자정에 실행 (초 분 시 일 월 요일)
-    @Scheduled(cron = "0 3 16 * * ?")
+    @Scheduled(cron = "0 0 0 * * ?")
     @Transactional
     public void resetFields() {
         memberRepository.resetFieldsToDefault(3);

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -4,6 +4,9 @@ spring:
   profiles:
     active: ec2
 
+  main:
+    time-zone: Asia/Seoul
+
   jpa:
     show-sql: true
     hibernate:


### PR DESCRIPTION
## 🦁 자정이 되면 사용자의 퀴즈 도전 기회를 초기화함

## 🎈 카테고리

- [x] User 관련
- [] Item 관련
- [] Snowman 관련

## 🕑 PR 생성 날짜

- 2024/11/17

## 🔍 작업 내용

- 스케줄러를 컴포넌트로 등록해서 지정된 시간(자정)이 되면 사용자의 chance 필드 초기화
- 스케줄러 동작 시간을 00시 00분으로 지정하고 spring 서버의 time-zone을 Asia/Seoul로 설정

## 📢 Notes

- 설정한 시간이 되었을 때 SQL 쿼리가 나가는 것과 DataGrip을 통해서 실제로 서버의 필드가 초기화된 것을 확인 완료함

## 🖼 스크린샷

![image](https://github.com/user-attachments/assets/4145e6b6-b120-4ac6-9e88-cee9ade0d351)

